### PR TITLE
Fix assignment to automatic variable

### DIFF
--- a/Invoke-mimikittenz.ps1
+++ b/Invoke-mimikittenz.ps1
@@ -529,7 +529,7 @@ Add-Type -TypeDefinition $Source2 -Language CSharp -CompilerParameters $inmem
     #Cpanel
     [mimikittenz.MemProcInspector]::AddRegex("Cpanel","user=.{1,50}&pass=.{1,50}")
 [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($asciiart))
-$matches=[mimikittenz.MemProcInspector]::InspectManyProcs("iexplore","chrome","firefox")
+$matchesFound=[mimikittenz.MemProcInspector]::InspectManyProcs("iexplore","chrome","firefox")
 
-write-output $matches
+write-output $matchesFound
 }


### PR DESCRIPTION
`$matches` is an automatic variable in PowerShell 2.0 and above. Current assignment works by overriding a local copy, but if anyone decides to fork Invoke-mimikittenz.ps1 and do any type of regex matching in PowerShell natively, they may be in for a grim surprise.
